### PR TITLE
extension for verification(keyfile) in load_cert_chain. 

### DIFF
--- a/uploadserver/__init__.py
+++ b/uploadserver/__init__.py
@@ -225,7 +225,6 @@ def serve_forever():
     assert hasattr(args, 'client_certificate')
     assert hasattr(args, 'directory') and type(args.directory) is str
     assert hasattr(args, 'private_key')
-
     
     if args.cgi:
         handler_class = CGIHTTPRequestHandler

--- a/uploadserver/__init__.py
+++ b/uploadserver/__init__.py
@@ -174,6 +174,7 @@ def ssl_wrap(socket):
     # Server certificate handling
     server_certificate = pathlib.Path(args.server_certificate).resolve()
 
+    # Private Key file existing
     privkey = None
     if args.privkey_file is not None:
         privkey = pathlib.Path(args.privkey_file).resolve()
@@ -186,6 +187,7 @@ def ssl_wrap(socket):
         print('Server certificate "{}" is inside web server root "{}", exiting'.format(server_certificate, server_root))
         sys.exit(3)
     
+    # Handling like HTTPS we treated. If keyfile is empty, keyfile is treated as none
     if privkey is not None:
         context.load_cert_chain(certfile=server_certificate, keyfile=privkey)
     else:

--- a/uploadserver/__init__.py
+++ b/uploadserver/__init__.py
@@ -175,9 +175,9 @@ def ssl_wrap(socket):
     server_certificate = pathlib.Path(args.server_certificate).resolve()
 
     # Private Key file existing
-    privkey = None
-    if args.privkey_file is not None:
-        privkey = pathlib.Path(args.privkey_file).resolve()
+    privatekey = None
+    if args.private_key is not None:
+        privatekey = pathlib.Path(args.private_key).resolve()
     
     if not server_certificate.is_file():
         print('Server certificate "{}" not found, exiting'.format(server_certificate))
@@ -188,8 +188,8 @@ def ssl_wrap(socket):
         sys.exit(3)
     
     # Handling like HTTPS we treated. If keyfile is empty, keyfile is treated as none
-    if privkey is not None:
-        context.load_cert_chain(certfile=server_certificate, keyfile=privkey)
+    if privatekey is not None:
+        context.load_cert_chain(certfile=server_certificate, keyfile=privatekey)
     else:
         context.load_cert_chain(certfile=server_certificate)
 
@@ -224,7 +224,7 @@ def serve_forever():
     assert hasattr(args, 'server_certificate')
     assert hasattr(args, 'client_certificate')
     assert hasattr(args, 'directory') and type(args.directory) is str
-    assert hasattr(args, 'privkey_file')
+    assert hasattr(args, 'private_key')
 
     
     if args.cgi:
@@ -295,7 +295,7 @@ def main():
         help='Specify HTTPS server certificate to use [default: none]')
     parser.add_argument('--client-certificate',
         help='Specify HTTPS client certificate to accept for mutual TLS [default: none]')
-    parser.add_argument('--privkey-file',
+    parser.add_argument('--private-key',
         help='Specify Server private key file for a real TLS connection [default: none]')
     
     # Directory option was added to http.server in Python 3.7

--- a/uploadserver/__init__.py
+++ b/uploadserver/__init__.py
@@ -173,6 +173,10 @@ def ssl_wrap(socket):
     
     # Server certificate handling
     server_certificate = pathlib.Path(args.server_certificate).resolve()
+
+    privkey = None
+    if args.privkey_file is not None:
+        privkey = pathlib.Path(args.privkey_file).resolve()
     
     if not server_certificate.is_file():
         print('Server certificate "{}" not found, exiting'.format(server_certificate))
@@ -182,8 +186,11 @@ def ssl_wrap(socket):
         print('Server certificate "{}" is inside web server root "{}", exiting'.format(server_certificate, server_root))
         sys.exit(3)
     
-    context.load_cert_chain(certfile=server_certificate)
-    
+    if privkey is not None:
+        context.load_cert_chain(certfile=server_certificate, keyfile=privkey)
+    else:
+        context.load_cert_chain(certfile=server_certificate)
+
     if args.client_certificate:
         # Client certificate handling
         client_certificate = pathlib.Path(args.client_certificate).resolve()
@@ -215,6 +222,8 @@ def serve_forever():
     assert hasattr(args, 'server_certificate')
     assert hasattr(args, 'client_certificate')
     assert hasattr(args, 'directory') and type(args.directory) is str
+    assert hasattr(args, 'privkey_file')
+
     
     if args.cgi:
         handler_class = CGIHTTPRequestHandler
@@ -284,6 +293,8 @@ def main():
         help='Specify HTTPS server certificate to use [default: none]')
     parser.add_argument('--client-certificate',
         help='Specify HTTPS client certificate to accept for mutual TLS [default: none]')
+    parser.add_argument('--privkey-file',
+        help='Specify Server private key file for a real TLS connection [default: none]')
     
     # Directory option was added to http.server in Python 3.7
     if sys.version_info.major > 3 or sys.version_info.minor >= 7:


### PR DESCRIPTION
Hi Densaugeo,

I have written an extension for the uploadserver. So far in the ssl_wrap under load_cert_chain it was assumed that keyfile=None. For the work in a company with CA it is important that the private key of the server can be set in keyfile(keyfile=privatekey).

Can you please add it to the project, I have tested it successfully. Please let me know if something else should be adjusted.

Many greetings
Toni