### PR TITLE
Use multipart module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
   - "3.11"
   - "3.12-dev"
 install:
-  - python -m pip install pytest requests
+  - python -m pip install pytest requests multipart
 script:
   - make test-travis

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test-travis: server.pem client.pem client.crt
 install-dev:
 	chmod 775 test-all.sh
 	$(PY) -m venv venv-$(PY)
-	. venv-$(PY)/bin/activate; $(PY) -m pip install pytest requests
+	. venv-$(PY)/bin/activate; $(PY) -m pip install pytest requests multipart
 
 server.pem:
 	openssl req -x509 -out server.pem -keyout server.pem -newkey rsa:2048 -nodes -sha256 -subj '/CN=server'

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,8 @@ setuptools.setup(
     python_requires='>=3.8',
     entry_points = {
         'console_scripts': ['uploadserver=uploadserver:main'],
-    }
+    },
+    install_requires=[
+        "multipart>=0.2,<0.3"
+    ]
 )


### PR DESCRIPTION
Hello,

I saw that the cgi module was deprecated and you had to save a copy to continue using it.

According to [the documentation](https://peps.python.org/pep-0594/#cgi), it is recommended to use [the multipart module](https://pypi.org/project/multipart/) instead:
> FieldStorage/MiniFieldStorage has no direct replacement, but can typically be replaced by using [multipart](https://pypi.org/project/multipart/) (for POST and PUT requests) or urllib.parse.parse_qsl (for GET and HEAD requests)

One of the advantages of this module is that it handles large files.

I remember [your following answer](https://github.com/Densaugeo/uploadserver/pull/7#issuecomment-898915096), but wanted to know whether you yould reconsider, instead of having to use an unsupported solution:
> I'm avoiding adding any dependencies outside Python's built-in modules, and keeping this module narrow in scope.

Best regards!